### PR TITLE
fix: set last_import to last complete day instead of latest timestamp

### DIFF
--- a/custom_components/ekz_ha/EkzFetcher.py
+++ b/custom_components/ekz_ha/EkzFetcher.py
@@ -208,15 +208,17 @@ class EkzFetcher:
         _LOGGER.debug(f"[import_full_history_to_statistics] Total statistics entries prepared: {len(statistics)}")
         last_full_day = max_date
 
-        # Set last_import and last_run_date in meta_entity if provided
+        # Set last_import and last_run_date in meta_entity if provided.
+        # Use max_date (last complete day) instead of the latest timestamp to avoid
+        # skipping partial-day data for today on the next import cycle.
         if meta_entity is not None:
-            if last_import is not None:
-                meta_entity.set_last_import(last_import.astimezone(ZRH).date())
-            elif to_date.date() < datetime.now(tz=ZRH).date():
-                # Data was fetched but no importable values found for this past period.
-                # Advance last_import to to_date to prevent an infinite retry loop.
+            if max_date is not None:
+                meta_entity.set_last_import(max_date.date())
+            elif not statistics and to_date.date() < datetime.now(tz=ZRH).date():
+                # No data at all for a past period — advance to prevent an infinite retry loop.
                 _LOGGER.info(f"[import_full_history_to_statistics] No importable data for {from_date.date()} to {to_date.date()} — advancing last_import to {to_date.date()} to avoid retry loop")
                 meta_entity.set_last_import(to_date.date())
+            # If statistics exist but max_date is None (only partial/today data), do not advance last_import.
             meta_entity.set_last_run_date(datetime.now())
         _LOGGER.debug(f"[import_full_history_to_statistics] Import finished: {len(statistics)} statistics entries, last_import={last_import}, last_full_day={last_full_day}")
         # Return the data for further processing

--- a/custom_components/ekz_ha/manifest.json
+++ b/custom_components/ekz_ha/manifest.json
@@ -15,5 +15,5 @@
     "beautifulsoup4>=4.0.0",
     "pyotp>=2.9.0"
   ],
-  "version": "0.1.0"
+  "version": "0.1.1b1"
 }

--- a/custom_components/ekz_ha/manifest.json
+++ b/custom_components/ekz_ha/manifest.json
@@ -15,5 +15,5 @@
     "beautifulsoup4>=4.0.0",
     "pyotp>=2.9.0"
   ],
-  "version": "0.1.1b1"
+  "version": "0.1.1"
 }


### PR DESCRIPTION
## What's Changed

### Bug Fix

**`last_import` was set to an incorrect date**

EKZ delivers 15-minute interval data with a delay of several days. Previously, `last_import` was set to the latest timestamp among all imported data points — which could include partial data for today. On the next import cycle, `from_date` would then be set to tomorrow, permanently skipping the days for which EKZ had not yet delivered complete data.

**Symptom:** The `Last Import` sensor showed today's date (at 02:00 CEST = midnight UTC), while consumption data only reached ~10 days back.

**Fix:** `last_import` is now set to the last **complete** day (determined by the expected number of 15-min slots per day, including DST switchover days).

### After Upgrading

A reload of the integration is recommended after updating. If `last_import` was already set to a future date, it may be necessary to clear the statistics DB and reload the integration.