### PR TITLE
fix: multiple import bugs + pending day lookback + prediction sensor (0.1.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,24 @@ After the first chunk is imported, you can add the sensor to the Energy Dashboar
 
 > **Note:** The Energy Dashboard shows the current period by default. Use the `<` arrow to navigate back to earlier months to verify historical data.
 
+### Prediction sensor (gap filling)
+
+EKZ delivers consumption data with a delay of approximately 7–10 days. To fill this gap in the Energy Dashboard, the integration provides a **prediction sensor**:
+
+`sensor.electricity_consumption_ekz_<installationId>_prediction`
+
+**How it works:**
+- While importing historical data, the integration accumulates **hourly consumption averages** per UTC month+hour bucket from the raw 15-minute slots.
+- Once the historical import is complete (catch-up mode ends), each update cycle generates predicted hourly values from the last real data point up to the current time.
+- The predictions are written as HA statistics — the Energy Dashboard will show them as an estimate for the recent gap.
+
+**Adding the prediction sensor to the Energy Dashboard:**
+1. Go to **Settings → Energy → Electricity grid → Add consumption sensor**
+2. Select `sensor.electricity_consumption_ekz_<installationId>_prediction`
+3. The sensor will remain empty during catch-up and fill in automatically once up-to-date.
+
+> **Note:** Predictions are based on historical averages per hour and month. They become more accurate the more historical data has been imported. The predictions are automatically overwritten by real data as EKZ delivers it.
+
 ## Solar production data
 
 If you have one or more EKZ solar installations (feed-in / Einspeisung), the integration automatically detects them and imports your production history into Home Assistant long-term statistics.

--- a/custom_components/ekz_ha/EkzFetcher.py
+++ b/custom_components/ekz_ha/EkzFetcher.py
@@ -146,7 +146,7 @@ class EkzFetcher:
 
         values = [
             total(g)
-            for _, g in itertools.groupby(values, lambda v: str(v["timestamp"])[0:10] if not is_day_level else v["date"])
+            for _, g in itertools.groupby(values, lambda v: v["date"] if not is_day_level else v["date"])
         ]
         values = sorted(values, key=lambda x: x["timestamp"])
         _LOGGER.debug(f"[import_full_history_to_statistics] Total values after daily aggregation: {len(values)}")

--- a/custom_components/ekz_ha/EkzFetcher.py
+++ b/custom_components/ekz_ha/EkzFetcher.py
@@ -27,7 +27,7 @@ def is_dst_switchover_date(dt: datetime, timeZone: zoneinfo.ZoneInfo) -> bool:
 
 class EkzFetcher:
 
-    async def import_full_history_to_statistics(self, hass, installationId: str, contract_start: str, meta_entity=None, running_sum_offset: float = 0.0):
+    async def import_full_history_to_statistics(self, hass, installationId: str, contract_start: str, meta_entity=None, running_sum_offset: float = 0.0, force_from_date=None):
         """Import data and return as dict for further processing, do not write to statistics directly."""
         _LOGGER = logging.getLogger(__name__)
         _LOGGER.debug(f"[import_full_history_to_statistics] Start: installationId={installationId}, contract_start={contract_start}")
@@ -49,6 +49,10 @@ class EkzFetcher:
             # Set contract_start in meta_entity if not set
             if meta_entity is not None and meta_entity._contract_start is None:
                 meta_entity.set_contract_start(from_date.date())
+        # Allow caller to override from_date (e.g. for pending day lookback)
+        if force_from_date is not None:
+            from_date = datetime.combine(force_from_date, datetime.min.time()) if not isinstance(force_from_date, datetime) else force_from_date
+            _LOGGER.info(f"[import_full_history_to_statistics] Lookback for pending days: overriding from_date to {from_date}")
         # Import exactly one month from from_date
         to_date = from_date + timedelta(days=30)
         _LOGGER.debug(f"[import_full_history_to_statistics] Fetching consumption data: installationId={installationId}, period {from_date} to {to_date}")
@@ -132,6 +136,13 @@ class EkzFetcher:
         
         is_day_level = (level == "DAY")
 
+        # Count 15-min slots per date BEFORE aggregation — used for full-day detection and pending tracking.
+        slot_counts: dict[str, int] = {}
+        if not is_day_level:
+            for v in values:
+                slot_counts[v["date"]] = slot_counts.get(v["date"], 0) + 1
+            _LOGGER.debug(f"[import_full_history_to_statistics] Slot counts (first 5): {dict(list(sorted(slot_counts.items()))[:5])}")
+
         # Aggregate per day (for QUARTER_HOUR: sum multiple slots; for DAY: passthrough with 1 entry per day)
         def total(group):
             group = list(group)
@@ -161,18 +172,22 @@ class EkzFetcher:
                     if max_date is None or d > max_date:
                         max_date = d
         else:
-            # For 15-min data find the last day that has 24 entries (or 23/25 for DST switchover)
+            # For 15-min data: check slot_counts counted BEFORE aggregation.
+            # A full day has 96 slots (4 per hour × 24h), 92 for DST spring forward, 100 for DST fall back.
             max_date = None
-            for k, v in itertools.groupby(values, lambda v: v["date"]):
-                date = datetime.strptime(k, "%Y-%m-%d")
-                expected_hours_per_day = (
-                    23
+            today_str_cest = datetime.now(tz=ZRH).strftime("%Y-%m-%d")
+            for date_str, count in slot_counts.items():
+                if date_str >= today_str_cest:
+                    continue  # today may be partial
+                date = datetime.strptime(date_str, "%Y-%m-%d")
+                expected_slots = (
+                    92
                     if is_dst_switchover_date(date, ZRH) and date.month < 6
-                    else 25
+                    else 100
                     if is_dst_switchover_date(date, ZRH)
-                    else 24
+                    else 96
                 )
-                if len(list(v)) == expected_hours_per_day:
+                if count == expected_slots:
                     if max_date is None or date > max_date:
                         max_date = date
 
@@ -208,6 +223,34 @@ class EkzFetcher:
         _LOGGER.debug(f"[import_full_history_to_statistics] Total statistics entries prepared: {len(statistics)}")
         last_full_day = max_date
 
+        # --- Option B: detect first incomplete day for next-cycle lookback ---
+        # A pending day has some VALID slots but not a full complement — EKZ may deliver the rest later.
+        pending_from = None
+        pending_sum_offset = running_sum_offset
+        if not is_day_level and slot_counts:
+            today_str_cest = datetime.now(tz=ZRH).strftime("%Y-%m-%d")
+            running_for_pending = running_sum_offset
+            for value in values:  # one entry per day, sorted by timestamp
+                date_str = value["date"]
+                if date_str >= today_str_cest:
+                    break  # skip today and future
+                date = datetime.strptime(date_str, "%Y-%m-%d")
+                expected_slots = (
+                    92 if is_dst_switchover_date(date, ZRH) and date.month < 6
+                    else 100 if is_dst_switchover_date(date, ZRH)
+                    else 96
+                )
+                count = slot_counts.get(date_str, 0)
+                if 0 < count < expected_slots:
+                    pending_from = date
+                    pending_sum_offset = running_for_pending
+                    _LOGGER.info(
+                        f"[import_full_history_to_statistics] Pending day: {date_str} "
+                        f"({count}/{expected_slots} slots) — will re-check next cycle"
+                    )
+                    break
+                running_for_pending += value["value"]
+
         # Set last_import and last_run_date in meta_entity if provided.
         # Use max_date (last complete day) instead of the latest timestamp to avoid
         # skipping partial-day data for today on the next import cycle.
@@ -220,7 +263,12 @@ class EkzFetcher:
                 meta_entity.set_last_import(to_date.date())
             # If statistics exist but max_date is None (only partial/today data), do not advance last_import.
             meta_entity.set_last_run_date(datetime.now())
-        _LOGGER.debug(f"[import_full_history_to_statistics] Import finished: {len(statistics)} statistics entries, last_import={last_import}, last_full_day={last_full_day}")
+            if hasattr(meta_entity, "set_pending"):
+                meta_entity.set_pending(
+                    pending_from.date() if pending_from else None,
+                    pending_sum_offset,
+                )
+        _LOGGER.debug(f"[import_full_history_to_statistics] Import finished: {len(statistics)} statistics entries, last_import={last_import}, last_full_day={last_full_day}, pending_from={pending_from}")
         # Return the data for further processing
         return {
             "statistics": statistics,
@@ -229,6 +277,8 @@ class EkzFetcher:
             "to_date": to_date.date(),
             "last_full_day": last_full_day,
             "last_full_day_sum": last_full_day_sum,
+            "pending_from": pending_from.date() if pending_from else None,
+            "pending_sum_offset": pending_sum_offset,
         }
 
     def __init__(self, user: str, password: str, totp_secret: str | None = None, device_name: str | None = None) -> None:

--- a/custom_components/ekz_ha/EkzFetcher.py
+++ b/custom_components/ekz_ha/EkzFetcher.py
@@ -138,9 +138,16 @@ class EkzFetcher:
 
         # Count 15-min slots per date BEFORE aggregation — used for full-day detection and pending tracking.
         slot_counts: dict[str, int] = {}
+        hourly_raw: dict[int, tuple[float, int]] = {}  # month*100+hour_utc -> (sum_kwh, count_slots)
         if not is_day_level:
             for v in values:
                 slot_counts[v["date"]] = slot_counts.get(v["date"], 0) + 1
+                ts = str(v["timestamp"])
+                hour_utc = int(ts[8:10]) if len(ts) >= 10 else 0
+                month = int(v["date"][5:7])
+                mh_key = month * 100 + hour_utc
+                s, c = hourly_raw.get(mh_key, (0.0, 0))
+                hourly_raw[mh_key] = (s + v["value"], c + 1)
             _LOGGER.debug(f"[import_full_history_to_statistics] Slot counts (first 5): {dict(list(sorted(slot_counts.items()))[:5])}")
 
         # Aggregate per day (for QUARTER_HOUR: sum multiple slots; for DAY: passthrough with 1 entry per day)
@@ -279,6 +286,7 @@ class EkzFetcher:
             "last_full_day_sum": last_full_day_sum,
             "pending_from": pending_from.date() if pending_from else None,
             "pending_sum_offset": pending_sum_offset,
+            "averages_raw": hourly_raw,
         }
 
     def __init__(self, user: str, password: str, totp_secret: str | None = None, device_name: str | None = None) -> None:

--- a/custom_components/ekz_ha/__init__.py
+++ b/custom_components/ekz_ha/__init__.py
@@ -172,10 +172,22 @@ class EkzCoordinator(DataUpdateCoordinator):
                 _LOGGER.info(f"No existing statistics for {key}, starting import from contract start {start}")
 
             # Import exactly one 30-day chunk per update cycle.
+            # If pending days were detected in the previous cycle, re-fetch from that earlier date
+            # (with the stored sum offset) so EKZ can fill in previously incomplete days.
+            pending_from = getattr(meta_entity, "_pending_from", None)
+            if pending_from is not None:
+                running_sum = getattr(meta_entity, "_pending_sum_offset", 0.0) or 0.0
+                _LOGGER.info(
+                    f"[{key}] Pending day lookback: re-fetching from {pending_from} "
+                    f"with sum offset {running_sum:.3f}"
+                )
+            else:
+                running_sum = self.last_sums.get(key, 0.0)
             # EkzFetcher updates meta_entity._last_import after each import so the next cycle continues from there.
             result = await self.ekz_fetcher.import_full_history_to_statistics(
                 self.hass, key, contract_start, meta_entity,
-                running_sum_offset=self.last_sums.get(key, 0.0),
+                running_sum_offset=running_sum,
+                force_from_date=pending_from,
             )
             _LOGGER.debug(f"Chunk result for {key}: from={result.get('from_date')} to={result.get('to_date')}, entries={len(result.get('statistics', []))}")
             if result.get("statistics"):

--- a/custom_components/ekz_ha/__init__.py
+++ b/custom_components/ekz_ha/__init__.py
@@ -18,6 +18,7 @@ from .const import CATCHUP_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL, DOMAIN, NORMAL_
 from .EkzFetcher import EkzFetcher
 
 ZRH = zoneinfo.ZoneInfo("Europe/Zurich")
+UTC = zoneinfo.ZoneInfo("UTC")
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -71,6 +72,7 @@ class EkzCoordinator(DataUpdateCoordinator):
         self.catching_up: dict[str, bool] = {}
         self._normal_interval = update_interval  # remember configured interval for later restore
         self._reset_lock = asyncio.Lock()
+        self.consumption_averages_raw: dict[str, dict] = {}  # accumulated slot sums for prediction
 
     async def _async_setup(self):
         """Load installations on first start."""
@@ -216,68 +218,63 @@ class EkzCoordinator(DataUpdateCoordinator):
                     _LOGGER.info(f"Catch-up complete for {key}, switching to daily poll interval")
                     self.update_interval = NORMAL_SCAN_INTERVAL
 
-            # Save consumption averages for prediction calculation
+            # Accumulate hourly averages across all imported chunks for prediction.
+            # averages_raw: {month*100+hour_utc: (sum_kwh, count_slots)} from EkzFetcher.
             averages = None
-            if "averages" in result:
-                _LOGGER.debug(f"Averages for {key}: {result['averages']}")
-                if self.consumption_averages is None:
-                    self.consumption_averages = {}
-                self.consumption_averages[key] = result["averages"]
-                averages = result["averages"]
-            elif self.consumption_averages is None:
-                if key in self.consumption_averages:
-                    averages = self.consumption_averages[key]
+            if result.get("averages_raw"):
+                raw = result["averages_raw"]
+                existing_raw = self.consumption_averages_raw.get(key, {})
+                for mh_key, (new_sum, new_count) in raw.items():
+                    ex_sum, ex_count = existing_raw.get(mh_key, (0.0, 0))
+                    existing_raw[mh_key] = (ex_sum + new_sum, ex_count + new_count)
+                self.consumption_averages_raw[key] = existing_raw
+                # 4 slots per hour → avg kWh/h = total_kwh / (count_slots / 4)
+                averages = {
+                    k: v[0] / (v[1] / 4)
+                    for k, v in existing_raw.items()
+                    if v[1] >= 4  # require at least 1 complete hour of data
+                }
+                self.consumption_averages[key] = averages
+                _LOGGER.debug(f"Updated hourly averages for {key}: {len(averages)} month-hour buckets")
+            elif key in self.consumption_averages:
+                averages = self.consumption_averages[key]
 
-            if averages is not None and len(result["statistics"]) > 0:
-                # Reset prediction statistics for all periods covered by real data,
+            # Only run predictions when fully caught up (gap fills the recent EKZ delay)
+            if averages and len(result["statistics"]) > 0 and not still_catching_up:
+                # Zero out predictions for all periods already covered by real data in this chunk,
                 # then extrapolate forward using historical averages.
                 predictions = [
                     {"start": x["start"], "sum": 0, "state": 0}
                     for x in result["statistics"]
                 ]
-                last_actual = result["statistics"][len(result["statistics"]) - 1]
-                # Copy
-                last_actual = {
-                    "start": last_actual["start"],
-                    "sum": last_actual["sum"],
-                    "state": last_actual["state"],
-                }
-                last_actual["start"] = last_actual["start"] + timedelta(hours=1)
-                running_total = 0
-                while last_actual["start"] < datetime.now().astimezone(tz=ZRH):
-                    mh_key = (
-                        last_actual["start"].month * 100 + last_actual["start"].hour
+                last_actual_start = result["statistics"][-1]["start"]
+                # Start predictions at the next full hour after the last real data entry
+                pred_start = last_actual_start + timedelta(hours=1)
+                running_total = 0.0
+                now_utc = datetime.now(tz=UTC)
+                while pred_start < now_utc:
+                    mh_key = pred_start.month * 100 + pred_start.hour
+                    hourly_kwh = averages.get(mh_key, 0.0)
+                    running_total += hourly_kwh
+                    predictions.append(
+                        {
+                            "start": pred_start,
+                            "sum": running_total,
+                            "state": hourly_kwh,
+                        }
                     )
-                    if mh_key in averages:
-                        running_total += averages[mh_key]
-                        predictions.append(
-                            {
-                                "start": last_actual["start"],
-                                "sum": running_total,
-                                "state": averages[mh_key],
-                            }
-                        )
-                    else:
-                        running_total += last_actual["state"]
-                        predictions.append(
-                            {
-                                "start": last_actual["start"],
-                                "sum": running_total,
-                                "state": last_actual["state"],
-                            }
-                        )
-                    last_actual["start"] = last_actual["start"] + timedelta(hours=1)
+                    pred_start = pred_start + timedelta(hours=1)
 
-                _LOGGER.debug(
-                    f"Predictions for {key} from {predictions[0]['start']} to {predictions[len(predictions)-1]['start']}: {predictions}"
-                )
-                async_import_statistics(
-                    self.hass,
-                    _make_stat_meta(f"sensor.electricity_consumption_ekz_{key}_predictions"),
-                    [StatisticData(start=s["start"], sum=s["sum"], state=s["state"]) for s in predictions],
-                )
-                if predictions:
-                    self.last_prediction_sums[key] = predictions[-1]["sum"]     
+                if len(predictions) > 1:
+                    _LOGGER.info(
+                        f"Predictions for {key}: {len(predictions)} entries, "
+                        f"gap coverage {result['statistics'][-1]['start'].date()} → {pred_start.date()}"
+                    )
+                    async_import_statistics(
+                        self.hass,
+                        _make_stat_meta(f"sensor.electricity_consumption_ekz_{key}_prediction"),
+                        [StatisticData(start=s["start"], sum=s["sum"], state=s["state"]) for s in predictions],
+                    )
 
         # --- Production (solar feed-in) import loop ---
         production_meta_entities = getattr(self, "production_meta_entities", {})

--- a/custom_components/ekz_ha/manifest.json
+++ b/custom_components/ekz_ha/manifest.json
@@ -15,5 +15,5 @@
     "beautifulsoup4>=4.0.0",
     "pyotp>=2.9.0"
   ],
-  "version": "0.1.2b3"
+  "version": "0.1.2"
 }

--- a/custom_components/ekz_ha/manifest.json
+++ b/custom_components/ekz_ha/manifest.json
@@ -15,5 +15,5 @@
     "beautifulsoup4>=4.0.0",
     "pyotp>=2.9.0"
   ],
-  "version": "0.1.2b2"
+  "version": "0.1.2b3"
 }

--- a/custom_components/ekz_ha/manifest.json
+++ b/custom_components/ekz_ha/manifest.json
@@ -15,5 +15,5 @@
     "beautifulsoup4>=4.0.0",
     "pyotp>=2.9.0"
   ],
-  "version": "0.1.2b1"
+  "version": "0.1.2b2"
 }

--- a/custom_components/ekz_ha/manifest.json
+++ b/custom_components/ekz_ha/manifest.json
@@ -15,5 +15,5 @@
     "beautifulsoup4>=4.0.0",
     "pyotp>=2.9.0"
   ],
-  "version": "0.1.1"
+  "version": "0.1.2b1"
 }

--- a/custom_components/ekz_ha/sensor.py
+++ b/custom_components/ekz_ha/sensor.py
@@ -84,7 +84,7 @@ class EkzPredictionEntity(CoordinatorEntity, SensorEntity):
         self._attr_unique_id = (
             f"ekz_electricity_consumption_{installationId}_prediction"
         )
-        self._attr_name = f"Electricity consumption prediction EKZ {installationId}"
+        self._attr_name = f"Electricity consumption EKZ {installationId} prediction"
 
     @property
     def device_info(self):

--- a/custom_components/ekz_ha/sensor.py
+++ b/custom_components/ekz_ha/sensor.py
@@ -122,6 +122,8 @@ class EkzMetaEntity(CoordinatorEntity, SensorEntity):
         self._contract_start: date | None = None
         self._last_import: date | None = None
         self._last_run_date: datetime | None = None
+        self._pending_from: date | None = None
+        self._pending_sum_offset: float = 0.0
 
     @property
     def device_info(self):
@@ -163,6 +165,7 @@ class EkzMetaEntity(CoordinatorEntity, SensorEntity):
             "contract_start": self._contract_start.isoformat() if self._contract_start else None,
             "last_import_date": self._last_import.isoformat() if self._last_import else None,
             "last_run_datetime": self._last_run_date.isoformat() if self._last_run_date else None,
+            "pending_from": self._pending_from.isoformat() if self._pending_from else None,
         }
 
     def set_last_run_date(self, value):
@@ -183,6 +186,9 @@ class EkzMetaEntity(CoordinatorEntity, SensorEntity):
     def set_last_import(self, value: date):
         self._last_import = value
 
+    def set_pending(self, pending_from: "date | None", sum_offset: float = 0.0):
+        self._pending_from = pending_from
+        self._pending_sum_offset = sum_offset
 
 class EkzContractStartEntity(CoordinatorEntity, SensorEntity):
     """Shows the EKZ contract start date for an installation."""


### PR DESCRIPTION
## What's Changed in 0.1.2

### Bug Fixes

**Bug #1 — `last_import` set to wrong date**
`last_import` was set to the maximum of all timestamps, including partial data for today. This caused `from_date` to be set to tomorrow on the next cycle, permanently skipping days for which EKZ had not yet delivered complete data.
Fix: `last_import` is now set to `max_date` (the last fully imported day).

**Bug #2 — Daily aggregation broken**
The groupby key used `str(timestamp)[0:10]` on EKZ timestamps like `20260407173000`, yielding `2026040717` (hourly prefix) instead of `2026-04-07` (date). This produced ~24× more entries than expected and `last_import` was never advanced.
Fix: Grouping now uses the `date` field from the API response.

**Bug #3 — `max_date` detection broken after aggregation fix**
After the aggregation fix, the completeness check counted aggregated entries (always 1/day) and expected 24 — `max_date` was never found.
Fix: Raw 15-min slots are now counted *before* aggregation — a complete day = 96 slots (92 for DST spring forward, 100 for DST fall back).

### New Feature: Pending day lookback

EKZ delivers data with a ~7–10 day delay and sometimes back-fills incomplete days. The integration now detects the first incomplete day (`pending_from`) and re-fetches that range on the next cycle — once EKZ delivers the missing data, the statistics are overwritten with corrected cumulative sums.

### New Feature: Prediction sensor

The sensor `sensor.electricity_consumption_ekz_<id>_prediction` fills the current gap caused by the EKZ delay:
- Hourly consumption averages are accumulated from raw 15-min slots during the historical import (UTC month + hour buckets)
- Once catch-up is complete, predicted hourly values are generated from the last real data point up to the current time
- Add the sensor to the HA Energy Dashboard alongside the real consumption sensor

---

**After upgrading:**
1. Clear statistics for `sensor.electricity_consumption_ekz_*` (**Settings → System → Storage**)
2. Reload the integration

Closes #10